### PR TITLE
Handle null content in APIResponse.

### DIFF
--- a/flask_api/request.py
+++ b/flask_api/request.py
@@ -16,7 +16,7 @@ class APIRequest(Request):
     negotiator_class = DefaultNegotiation
     empty_data_class = MultiDict
 
-    # Request parsing...
+    # Request parsing...
 
     @property
     def data(self):
@@ -80,7 +80,7 @@ class APIRequest(Request):
         self._form = self.empty_data_class()
         self._files = self.empty_data_class()
 
-    # Content negotiation...
+    # Content negotiation...
 
     @property
     def accepted_renderer(self):
@@ -103,7 +103,7 @@ class APIRequest(Request):
         renderers = [renderer() for renderer in self.renderer_classes]
         self._accepted_renderer, self._accepted_media_type = negotiator.select_renderer(renderers)
 
-    # Method and content type overloading.
+    # Method and content type overloading.
 
     @property
     def method(self):
@@ -145,7 +145,7 @@ class APIRequest(Request):
         self._content_length = get_content_length(self.environ)
 
         if (self._method == 'POST' and self._content_type == 'application/x-www-form-urlencoded'):
-            # Read the request data, then push it back onto the stream again.
+            # Read the request data, then push it back onto the stream again.
             body = self.get_data()
             data = url_decode_stream(io.BytesIO(body))
             self._stream = io.BytesIO(body)

--- a/flask_api/response.py
+++ b/flask_api/response.py
@@ -18,6 +18,9 @@ class APIResponse(Response):
                 if self.status_code == 204:
                     self.status_code = 200
 
+        # From `werkzeug.wrappers.BaseResponse`
+        if content is None:
+            content = []
         if isinstance(content, (text_type, bytes, bytearray)):
             self.set_data(content)
         else:

--- a/flask_api/tests/test_app.py
+++ b/flask_api/tests/test_app.py
@@ -48,6 +48,11 @@ def abort_view():
     abort(status.HTTP_403_FORBIDDEN)
 
 
+@app.route('/options/')
+def options_view():
+    return {}
+
+
 @app.route('/accepted_media_type/')
 @set_renderers([JSONVersion2, JSONVersion1])
 def accepted_media_type():
@@ -94,6 +99,12 @@ class AppTests(unittest.TestCase):
         with app.test_client() as client:
             response = client.get('/abort_view/')
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_options_view(self):
+        with app.test_client() as client:
+            response = client.options('/options/')
+        # Errors if `response.response` is `None`
+        response.get_data()
 
     def test_accepted_media_type_property(self):
         with app.test_client() as client:


### PR DESCRIPTION
TL;DR: Fix OPTIONS requests generated by cross-origin requests.

When a Flask app receives an OPTIONS request, it will by default call
its make_default_options_response method, which instantiates its
response_class with no arguments. In vanilla Flask, creating a Response
object with no arguments populates the response field of the resulting
object with an empty list. But instantiating APIResponse with no
arguments results in a response field set to None, which raises an error
on calling get_data: response must be iterable. This patch borrows
error-checking logic from Werkzeug and sets the response field to an
empty list if the content argument passed to the APIResponse constructor
is None.