### PR TITLE
Content negotiation improvements

### DIFF
--- a/flask_api/mediatypes.py
+++ b/flask_api/mediatypes.py
@@ -61,7 +61,7 @@ class MediaType(object):
         """
         full_type, sep, param_string = media_type.partition(';')
         params = {}
-        for token in param_string.strip().split(','):
+        for token in param_string.split(';'):
             key, sep, value = [s.strip() for s in token.partition('=')]
             if value.startswith('"') and value.endswith('"'):
                 value = value[1:-1]

--- a/flask_api/mediatypes.py
+++ b/flask_api/mediatypes.py
@@ -28,6 +28,10 @@ class MediaType(object):
             return 2
         return 3
 
+    @property
+    def quality(self):
+        return float(self.params.get('q', 1.0))
+
     def satisfies(self, other):
         """
         Returns `True` if this media type is a superset of `other`.
@@ -105,8 +109,10 @@ def parse_accept_header(accept):
         set([<MediaType "*/*">])
     ]
     """
-    ret = [set(), set(), set(), set()]
+    ret = [[], [], [], []]
     for token in accept.split(','):
         media_type = MediaType(token.strip())
-        ret[3 - media_type.precedence].add(media_type)
-    return [media_types for media_types in ret if media_types]
+        ret[3 - media_type.precedence].append(media_type)
+
+    return [sorted(media_types, key=lambda t: -t.quality)
+            for media_types in ret if media_types]

--- a/flask_api/negotiation.py
+++ b/flask_api/negotiation.py
@@ -46,6 +46,12 @@ class DefaultNegotiation(BaseNegotiation):
                         if server_media_type.precedence > client_media_type.precedence:
                             return (renderer, server_media_type)
                         else:
+                            try:
+                                # Don't send q parameter back to the client
+                                del client_media_type.params['q']
+                            except KeyError:
+                                pass
+
                             return (renderer, client_media_type)
 
         raise exceptions.NotAcceptable()

--- a/flask_api/tests/test_mediatypes.py
+++ b/flask_api/tests/test_mediatypes.py
@@ -98,22 +98,20 @@ class AcceptHeaderTests(unittest.TestCase):
     def test_parse_simple_accept_header(self):
         parsed = parse_accept_header('*/*, application/json')
         self.assertEqual(parsed, [
-            set([MediaType('application/json')]),
-            set([MediaType('*/*')])
+            [MediaType('application/json')],
+            [MediaType('*/*')]
         ])
 
     def test_parse_complex_accept_header(self):
         """
         The accept header should be parsed into a list of sets of MediaType.
-        The list is an ordering of precedence.
-
-        Note that we disregard 'q' values when determining precedence, and
-        instead differentiate equal values by using the server preference.
+        The list is an ordering of precedence and sublists are in the order
+        of quality.
         """
         header = 'application/xml; schema=foo, application/json; q=0.9, application/xml, */*'
         parsed = parse_accept_header(header)
         self.assertEqual(parsed, [
-            set([MediaType('application/xml; schema=foo')]),
-            set([MediaType('application/json; q=0.9'), MediaType('application/xml')]),
-            set([MediaType('*/*')]),
+            [MediaType('application/xml; schema=foo')],
+            [MediaType('application/xml'), MediaType('application/json; q=0.9')],
+            [MediaType('*/*')],
         ])

--- a/flask_api/tests/test_mediatypes.py
+++ b/flask_api/tests/test_mediatypes.py
@@ -6,7 +6,7 @@ import unittest
 
 class MediaTypeParsingTests(unittest.TestCase):
     def test_media_type_with_params(self):
-        media = MediaType('application/xml; schema=foobar, q=0.5')
+        media = MediaType('application/xml; schema=foobar; q=0.5')
         self.assertEqual(str(media), 'application/xml; q="0.5", schema="foobar"')
         self.assertEqual(media.main_type, 'application')
         self.assertEqual(media.sub_type, 'xml')

--- a/flask_api/tests/test_negotiation.py
+++ b/flask_api/tests/test_negotiation.py
@@ -48,6 +48,15 @@ class TestRendererNegotiation(unittest.TestCase):
             self.assertEqual(renderer, JSON)
             self.assertEqual(str(media_type), 'application/json')
 
+    def test_select_rendered_client_preference(self):
+        negotiation = DefaultNegotiation()
+        renderers = [JSON, HTML]
+        headers = {'Accept': 'application/json; q=0.5, application/html'}
+        with app.test_request_context(headers=headers):
+            renderer, media_type = negotiation.select_renderer(renderers)
+            self.assertEqual(renderer, JSON)
+            self.assertEqual(str(media_type), 'application/json')
+
     def test_select_renderer_failed(self):
         negotiation = DefaultNegotiation()
         renderers = [JSON, HTML]


### PR DESCRIPTION
*This came from #29 and has been moved to its own branch. (Which I should have done in the first place.)*

These changes fix a couple of content negotiation issues.

The original code expected media type parameters to be separated with commas, when they should actually be separated with semicolons.

I've also added support for the quality (q) parameter to allow the client to better influence the rendered that is selected.