### PR TITLE
Headers should be escaped on browser

### DIFF
--- a/flask_api/templates/base.html
+++ b/flask_api/templates/base.html
@@ -117,7 +117,7 @@
             </div>
             <div class="response-info">
                 <pre class="prettyprint"><div class="meta nocode"><b>HTTP {{ status }}</b>{% autoescape off %}
-{% for key, val in headers.items() %}<b>{{ key }}:</b> <span class="lit">{{ val }}<!--{ val|break_long_headers|urlize_quoted_links }--></span>
+{% for key, val in headers.items() %}<b>{{ key }}:</b> <span class="lit">{{ val|e }}<!--{ val|break_long_headers|urlize_quoted_links }--></span>
 {% endfor %}
 </div>{% if content %}{{ content|urlize_quoted_links }}{% endif %}<!-- |urlize_quoted_links --></pre>{% endautoescape %}
             </div>


### PR DESCRIPTION
Link header have `<>` expression that is not shown on browser:

```
Link:
<https://api.github.com/search/code?q=addClass+user%3Amozilla&page=15>;
rel="next",
  <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=34>;
rel="last",
  <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=1>;
rel="first",
  <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=13>;
rel="prev"
```

See the details:

- https://developer.github.com/guides/traversing-with-pagination/