### PR TITLE
Update page titles to match to docs

### DIFF
--- a/flask_api/renderers.py
+++ b/flask_api/renderers.py
@@ -42,7 +42,9 @@ def dedent(content):
 
 
 def convert_to_title(name):
-    return name.replace('-', ' ').replace('_', ' ').capitalize()
+    for char in ['-', '_', '.']:
+        name = name.replace(char, ' ')
+    return name.capitalize()
 
 
 class BaseRenderer(object):


### PR DESCRIPTION
The docs show "Notes detail" not "Notes.detail".