### PR TITLE
typecast blueprint_handlers and app_handlers

### DIFF
--- a/flask_api/app.py
+++ b/flask_api/app.py
@@ -94,7 +94,8 @@ class FlaskAPI(Flask):
                 if isinstance(e, typecheck):
                     return handler(e)
         else:
-            for typecheck, handler in chain(blueprint_handlers.items(), app_handlers.items()):
+            for typecheck, handler in chain(dict(blueprint_handlers).items(),
+                    dict(app_handlers).items()):
                 if isinstance(e, typecheck):
                     return handler(e)
 


### PR DESCRIPTION
This fix has been submitted following the discussion for [THIS issue](https://github.com/tomchristie/flask-api/issues/61) . `blueprint_handlers` and `app_handlers` are expected to be of type dict even-though they are of type tuple. We can typecast to fix that. 