### PR TITLE
Disable API rendering for non-empty text

### DIFF
--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -4,7 +4,7 @@ This software is made available under the terms of a [BSD 2-Clause license][bsd-
 
 ---
 
-Copyright &copy; 2015, Tom Christie
+Copyright &copy; 2017, Tom Christie
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,6 +1,10 @@
 # Release Notes
 
-This project is currently in alpha.  It is functional and well tested but you are advised to pay close attention to the release notes when upgrading to future versions.
+This project is currently in beta.  It is functional and well tested but you are advised to pay close attention to the release notes when upgrading to future versions.
+
+## Version 0.7 (unreleased)
+
+Disabled rendering of text responses as API views.
 
 ## Version 0.6.9
 

--- a/flask_api/__init__.py
+++ b/flask_api/__init__.py
@@ -1,3 +1,3 @@
 from flask_api.app import FlaskAPI
 
-__version__ = '0.6.9'
+__version__ = '0.7b1'

--- a/flask_api/__init__.py
+++ b/flask_api/__init__.py
@@ -1,3 +1,3 @@
 from flask_api.app import FlaskAPI
 
-__version__ = '0.7b1'
+__version__ = '0.7b2'

--- a/flask_api/app.py
+++ b/flask_api/app.py
@@ -1,7 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals
 from flask import request, Flask, Blueprint
-from flask._compat import reraise, string_types
+from flask._compat import reraise, string_types, text_type
 from flask_api.exceptions import APIException
 from flask_api.request import APIRequest
 from flask_api.response import APIResponse
@@ -55,7 +55,7 @@ class FlaskAPI(Flask):
             headers, status_or_headers = status_or_headers, None
 
         if not isinstance(rv, self.response_class):
-            if isinstance(rv, (bytes, bytearray, list, dict)):
+            if isinstance(rv, (text_type, bytes, bytearray, list, dict)):
                 rv = self.response_class(rv, headers=headers, status=status_or_headers)
                 headers = status_or_headers = None
             else:

--- a/flask_api/app.py
+++ b/flask_api/app.py
@@ -1,7 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals
 from flask import request, Flask, Blueprint
-from flask._compat import reraise, string_types, text_type
+from flask._compat import reraise, string_types
 from flask_api.exceptions import APIException
 from flask_api.request import APIRequest
 from flask_api.response import APIResponse
@@ -55,7 +55,7 @@ class FlaskAPI(Flask):
             headers, status_or_headers = status_or_headers, None
 
         if not isinstance(rv, self.response_class):
-            if isinstance(rv, (text_type, bytes, bytearray, list, dict)):
+            if isinstance(rv, (bytes, bytearray, list, dict)):
                 rv = self.response_class(rv, headers=headers, status=status_or_headers)
                 headers = status_or_headers = None
             else:

--- a/flask_api/response.py
+++ b/flask_api/response.py
@@ -1,7 +1,6 @@
 # coding: utf8
 from __future__ import unicode_literals
 from flask import request, Response
-from flask._compat import text_type, string_types
 
 
 class APIResponse(Response):
@@ -9,7 +8,7 @@ class APIResponse(Response):
         super(APIResponse, self).__init__(None, *args, **kwargs)
 
         media_type = None
-        if isinstance(content, (list, dict, text_type, string_types)):
+        if isinstance(content, (list, dict)) or content == '':
             renderer = request.accepted_renderer
             if content != '' or renderer.handles_empty_responses:
                 media_type = request.accepted_media_type
@@ -21,7 +20,7 @@ class APIResponse(Response):
         # From `werkzeug.wrappers.BaseResponse`
         if content is None:
             content = []
-        if isinstance(content, (text_type, bytes, bytearray)):
+        if isinstance(content, (bytes, bytearray)):
             self.set_data(content)
         else:
             self.response = content

--- a/flask_api/response.py
+++ b/flask_api/response.py
@@ -1,6 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals
 from flask import request, Response
+from flask._compat import text_type
 
 
 class APIResponse(Response):
@@ -20,7 +21,7 @@ class APIResponse(Response):
         # From `werkzeug.wrappers.BaseResponse`
         if content is None:
             content = []
-        if isinstance(content, (bytes, bytearray)):
+        if isinstance(content, (text_type, bytes, bytearray)):
             self.set_data(content)
         else:
             self.response = content

--- a/setup.py
+++ b/setup.py
@@ -78,16 +78,19 @@ setup(
     package_data=get_package_data(package),
     install_requires=install_requires,
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
+        'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
-        'Framework :: Django',
+        'Framework :: Flask',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )


### PR DESCRIPTION
This is a partial attempt at #13. I don't think that Flask-API should ever try to render text (such as the output of `render_template`) using an API renderer. API responses are lists or dictionaries.