### PR TITLE
Delete deprecated safe_mode argument

### DIFF
--- a/flask_api/compat.py
+++ b/flask_api/compat.py
@@ -13,8 +13,7 @@ try:
         """
 
         extensions = ['headerid(level=2)']
-        safe_mode = False
-        md = markdown.Markdown(extensions=extensions, safe_mode=safe_mode)
+        md = markdown.Markdown(extensions=extensions)
         return md.convert(text)
 
 


### PR DESCRIPTION
safe_mode arg was deprecated since Markdown 2.6, so there is no need to use it and it just spams logs with DeprecationWarning

https://pythonhosted.org/Markdown/release-2.6.html#safe_mode-deprecated